### PR TITLE
Feat add mac hashing environment vars

### DIFF
--- a/gcp/kubernetes.tf
+++ b/gcp/kubernetes.tf
@@ -21,7 +21,7 @@ resource "google_container_node_pool" "np" {
   name       = "${var.default_node_pool_name}"
   zone       = "europe-west3-a"
   cluster    = "${google_container_cluster.primary.name}"
-  node_count = 2
+  node_count = 3
 
   node_config {
     machine_type = "n1-standard-1"

--- a/kubernetes/deployments/tracking-ingestion-service.yml
+++ b/kubernetes/deployments/tracking-ingestion-service.yml
@@ -28,6 +28,16 @@ spec:
           value: /var/secrets/google/key.json
         - name: PUBSUB_TOPICID
           value: ingestion-prod
+        - name: MAC_SALT
+          valueFrom:
+            secretKeyRef:
+              name: mac-hashing
+              key: salt
+        - name: MAC_PEPPER
+          valueFrom:
+            secretKeyRef:
+              name: mac-hashing
+              key: pepper
         - name: SENTRY_DSN
           value: https://e95b3a253e8040f9a32af069e5c6cdc8@sentry.io/1318093
         livenessProbe:


### PR DESCRIPTION
# What?

- add hashing secrets as environment variable
- scaled default node pool to 3x `n1-standard-1`

# Why?

We still have credit and more ressources are making things easier