### PR TITLE
Feat resolve app CNAME to dashboard, fix kubernetes config

### DIFF
--- a/gcp/kubernetes.tf
+++ b/gcp/kubernetes.tf
@@ -12,7 +12,7 @@ resource "google_container_cluster" "primary" {
   node_pool = [
     {
       name = "${var.default_node_pool_name}"
-      node_count= 2
+      node_count= 3
     }
   ]
 }

--- a/kubernetes/certificates/crt-app-triangl-io.yml
+++ b/kubernetes/certificates/crt-app-triangl-io.yml
@@ -1,0 +1,17 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: crt-app-triangl-io
+spec:
+  secretName: crt-app-triangl-io
+  dnsNames:
+  - triangl.io
+  acme:
+    config:
+    - http01:
+        ingressClass: nginx
+      domains:
+      - triangl.io
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer

--- a/kubernetes/ingress.yml
+++ b/kubernetes/ingress.yml
@@ -14,10 +14,13 @@ spec:
     - triangl.io
     secretName: crt-triangl-io
   - hosts:
+    - app.triangl.io
+    secretName: crt-app-triangl-io
+  - hosts:
     - api.triangl.io
     secretName: crt-api-triangl-io
   rules:
-  - host: triangl.io
+  - host: app.triangl.io
     http:
       paths:
       - path: /


### PR DESCRIPTION
# What?

Resolve `https://app.triangl.io` to `triangl-dashboard`

# Why?

`https://triangl.io` is used by our landing-page now